### PR TITLE
Add InputSection with toggle

### DIFF
--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import InputSection from './InputSection.jsx'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -28,6 +29,9 @@ function App() {
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>
+      <div className="mt-6">
+        <InputSection />
+      </div>
     </>
   )
 }

--- a/my-app/src/InputSection.jsx
+++ b/my-app/src/InputSection.jsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+
+function InputSection() {
+  const [mode, setMode] = useState('text')
+
+  const toggleMode = () => {
+    setMode((prev) => (prev === 'text' ? 'voice' : 'text'))
+  }
+
+  return (
+    <div className="p-4 bg-sky-50 rounded-md shadow-md">
+      <div className="flex items-center justify-center mb-4">
+        <span className={`mr-3 font-medium ${mode === 'text' ? 'text-teal-600' : 'text-gray-500'}`}>Text Input</span>
+        <label className="relative inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            className="sr-only peer"
+            checked={mode === 'voice'}
+            onChange={toggleMode}
+          />
+          <div className="w-11 h-6 bg-gray-200 rounded-full peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-teal-500 peer-checked:bg-teal-500"></div>
+          <div className="absolute top-0 left-0 w-6 h-6 bg-white border border-gray-300 rounded-full transition-transform peer-checked:translate-x-full"></div>
+        </label>
+        <span className={`ml-3 font-medium ${mode === 'voice' ? 'text-teal-600' : 'text-gray-500'}`}>Voice Input</span>
+      </div>
+      {mode === 'text' ? (
+        <textarea
+          className="w-full h-32 p-3 border rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500 resize-none"
+          placeholder="Type your text here..."
+        />
+      ) : (
+        <div className="flex flex-col items-center">
+          <div className="w-full h-32 p-3 mb-4 border rounded-md flex items-center justify-center text-gray-500 bg-white">
+            Listening...
+          </div>
+          <button className="p-3 bg-teal-500 text-white rounded-full hover:bg-teal-600 focus:outline-none">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              className="w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 1v2m0 14a4 4 0 004-4V7a4 4 0 10-8 0v6a4 4 0 004 4zm0 0v5m-4 0h8"
+              />
+            </svg>
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default InputSection

--- a/my-app/tailwind.config.js
+++ b/my-app/tailwind.config.js
@@ -1,7 +1,7 @@
-module.exports = {
+export default {
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {},
   },
   plugins: [],
-};
+}


### PR DESCRIPTION
## Summary
- add new `InputSection` component with text and voice input modes
- highlight active mode using a Tailwind-based toggle
- import and render `InputSection` from `App.jsx`
- convert `tailwind.config.js` to ESM to satisfy lint rules

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888d7742920832bbe79eba1a927d022