### PR TITLE
Refine app layout and add recipient selector

### DIFF
--- a/my-app/src/App.css
+++ b/my-app/src/App.css
@@ -2,41 +2,4 @@
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -1,38 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 import InputSection from './InputSection.jsx'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-      <div className="mt-6">
-        <InputSection />
-      </div>
-    </>
+    <div className="max-w-screen-md mx-auto mt-8 px-4">
+      <InputSection />
+    </div>
   )
 }
 

--- a/my-app/src/InputSection.jsx
+++ b/my-app/src/InputSection.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import RecipientSelector from './RecipientSelector.jsx'
 
 function InputSection() {
   const [mode, setMode] = useState('text')
@@ -8,9 +9,10 @@ function InputSection() {
   }
 
   return (
-    <div className="p-4 bg-sky-50 rounded-md shadow-md">
-      <div className="flex items-center justify-center mb-4">
-        <span className={`mr-3 font-medium ${mode === 'text' ? 'text-teal-600' : 'text-gray-500'}`}>Text Input</span>
+    <div className="bg-gray-100 rounded-xl px-4 py-3 space-y-4 shadow-md">
+      <RecipientSelector />
+      <div className="flex items-center justify-center gap-4">
+        <span className={`font-medium ${mode === 'text' ? 'text-teal-600' : 'text-gray-500'}`}>Text</span>
         <label className="relative inline-flex items-center cursor-pointer">
           <input
             type="checkbox"
@@ -21,7 +23,7 @@ function InputSection() {
           <div className="w-11 h-6 bg-gray-200 rounded-full peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-teal-500 peer-checked:bg-teal-500"></div>
           <div className="absolute top-0 left-0 w-6 h-6 bg-white border border-gray-300 rounded-full transition-transform peer-checked:translate-x-full"></div>
         </label>
-        <span className={`ml-3 font-medium ${mode === 'voice' ? 'text-teal-600' : 'text-gray-500'}`}>Voice Input</span>
+        <span className={`font-medium ${mode === 'voice' ? 'text-teal-600' : 'text-gray-500'}`}>Voice</span>
       </div>
       {mode === 'text' ? (
         <textarea
@@ -29,8 +31,8 @@ function InputSection() {
           placeholder="Type your text here..."
         />
       ) : (
-        <div className="flex flex-col items-center">
-          <div className="w-full h-32 p-3 mb-4 border rounded-md flex items-center justify-center text-gray-500 bg-white">
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-full h-32 p-3 border rounded-md flex items-center justify-center text-gray-500 bg-white">
             Listening...
           </div>
           <button className="p-3 bg-teal-500 text-white rounded-full hover:bg-teal-600 focus:outline-none">

--- a/my-app/src/RecipientSelector.jsx
+++ b/my-app/src/RecipientSelector.jsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+
+function RecipientSelector() {
+  const [recipient, setRecipient] = useState('')
+  const [customRecipient, setCustomRecipient] = useState('')
+
+  const handleChange = (e) => {
+    setRecipient(e.target.value)
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="font-medium text-gray-700">Recipient</label>
+      <select
+        className="border rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-teal-500"
+        value={recipient}
+        onChange={handleChange}
+      >
+        <option value="">Select Recipient</option>
+        <option>Boss</option>
+        <option>Client</option>
+        <option>Coworker</option>
+        <option>Subordinate</option>
+        <option>Lecturer</option>
+        <option>Student</option>
+        <option>Custom</option>
+      </select>
+      {recipient === 'Custom' && (
+        <input
+          type="text"
+          className="border rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-teal-500"
+          placeholder="Enter custom recipient"
+          value={customRecipient}
+          onChange={(e) => setCustomRecipient(e.target.value)}
+        />
+      )}
+    </div>
+  )
+}
+
+export default RecipientSelector


### PR DESCRIPTION
## Summary
- remove default Vite template UI
- create `RecipientSelector` component and use it inside the input section
- style the input switcher card with Tailwind classes
- simplify `App.css`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888d94c8e50832bbd21688e7715ceba