### PR TITLE
Add RetrySection component

### DIFF
--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -1,12 +1,17 @@
 import './App.css'
+import { useState } from 'react'
 import InputSection from './InputSection.jsx'
 import PolitenessSlider from './PolitenessSlider.jsx'
+import RetrySection from './RetrySection.jsx'
 
 function App() {
+  const [inputText, setInputText] = useState('')
+
   return (
     <div className="max-w-screen-md mx-auto mt-10 px-4 space-y-6">
-      <InputSection />
+      <InputSection inputValue={inputText} onInputChange={setInputText} />
       <PolitenessSlider />
+      <RetrySection previousInput={inputText} />
     </div>
   )
 }

--- a/my-app/src/InputSection.jsx
+++ b/my-app/src/InputSection.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import RecipientSelector from './RecipientSelector.jsx'
 
-function InputSection() {
+function InputSection({ inputValue, onInputChange }) {
   const [mode, setMode] = useState('text')
 
 
@@ -26,6 +26,8 @@ function InputSection() {
         <textarea
           className="w-full h-32 p-3 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500 resize-none"
           placeholder="Type your text here..."
+          value={inputValue}
+          onChange={(e) => onInputChange(e.target.value)}
         />
       ) : (
         <div className="flex flex-col items-center gap-4">

--- a/my-app/src/RetrySection.jsx
+++ b/my-app/src/RetrySection.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+
+function RetrySection({ previousInput }) {
+  const [feedback, setFeedback] = useState('')
+
+  const handleRetry = () => {
+    console.log('Retrying with input:', previousInput, 'Feedback:', feedback)
+    // API call will be integrated here
+    setFeedback('')
+  }
+
+  return (
+    <div className="bg-gray-100 rounded-md p-4 space-y-2">
+      <label htmlFor="retry-feedback" className="block text-sm font-medium text-gray-700">
+        Optional Feedback
+      </label>
+      <textarea
+        id="retry-feedback"
+        className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-600 resize-none"
+        placeholder="e.g., Make it shorter or Too formal"
+        value={feedback}
+        onChange={(e) => setFeedback(e.target.value)}
+      />
+      <button
+        onClick={handleRetry}
+        className="bg-blue-600 text-white rounded-md px-4 py-2 hover:bg-blue-700"
+      >
+        Retry
+      </button>
+    </div>
+  )
+}
+
+export default RetrySection


### PR DESCRIPTION
## Summary
- add new `RetrySection` component for optional feedback and retrying
- wire up `InputSection` to send input value to `RetrySection`
- update `App` to include `RetrySection` and maintain input text state

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888dd5e8898832bb096e0706c47f0e8