### PR TITLE
Connect React app to ChatGPT API

### DIFF
--- a/my-app/.gitignore
+++ b/my-app/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -3,15 +3,80 @@ import { useState } from 'react'
 import InputSection from './InputSection.jsx'
 import PolitenessSlider from './PolitenessSlider.jsx'
 import RetrySection from './RetrySection.jsx'
+import OutputSection from './OutputSection.jsx'
 
 function App() {
   const [inputText, setInputText] = useState('')
+  const [recipient, setRecipient] = useState('')
+  const [customRecipient, setCustomRecipient] = useState('')
+  const [politeness, setPoliteness] = useState(3)
+  const [feedback, setFeedback] = useState('')
+  const [output, setOutput] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const getAudience = () => {
+    return recipient === 'Custom' ? customRecipient || 'Custom' : recipient || 'General'
+  }
+
+  const handleSubmit = async () => {
+    const promptParts = [
+      'Please rewrite this message to be more polite.',
+      `Audience: ${getAudience()}.`,
+      `Politeness level: ${politeness}.`,
+    ]
+    if (feedback) {
+      promptParts.push(`Feedback: ${feedback}.`)
+    }
+    promptParts.push(`Original message: ${inputText}`)
+
+    const prompt = promptParts.join(' ')
+
+    setLoading(true)
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [{ role: 'user', content: prompt }],
+        }),
+      })
+
+      const data = await res.json()
+      setOutput(data.choices?.[0]?.message?.content?.trim() || '')
+    } catch (err) {
+      console.error(err)
+      setOutput('Failed to fetch response.')
+    } finally {
+      setLoading(false)
+    }
+  }
 
   return (
     <div className="max-w-screen-md mx-auto mt-10 px-4 space-y-6">
-      <InputSection inputValue={inputText} onInputChange={setInputText} />
-      <PolitenessSlider />
-      <RetrySection previousInput={inputText} />
+      <InputSection
+        inputValue={inputText}
+        onInputChange={setInputText}
+        recipient={recipient}
+        customRecipient={customRecipient}
+        onRecipientChange={setRecipient}
+        onCustomRecipientChange={setCustomRecipient}
+        onSubmit={handleSubmit}
+      />
+      <PolitenessSlider level={politeness} onLevelChange={setPoliteness} />
+      <RetrySection
+        feedback={feedback}
+        onFeedbackChange={setFeedback}
+        onRetry={handleSubmit}
+      />
+      {loading ? (
+        <div className="text-center text-gray-600">Filtering...</div>
+      ) : (
+        <OutputSection output={output} />
+      )}
     </div>
   )
 }

--- a/my-app/src/InputSection.jsx
+++ b/my-app/src/InputSection.jsx
@@ -1,13 +1,26 @@
 import { useState } from 'react'
 import RecipientSelector from './RecipientSelector.jsx'
 
-function InputSection({ inputValue, onInputChange }) {
+function InputSection({
+  inputValue,
+  onInputChange,
+  recipient,
+  customRecipient,
+  onRecipientChange,
+  onCustomRecipientChange,
+  onSubmit,
+}) {
   const [mode, setMode] = useState('text')
 
 
   return (
     <div className="bg-white rounded-xl p-6 space-y-6 shadow-md text-gray-700">
-      <RecipientSelector />
+      <RecipientSelector
+        recipient={recipient}
+        customRecipient={customRecipient}
+        onRecipientChange={onRecipientChange}
+        onCustomRecipientChange={onCustomRecipientChange}
+      />
       <div className="flex items-center justify-center gap-0 rounded-md overflow-hidden border divide-x w-max mx-auto">
         <button
           className={`px-4 py-2 text-sm font-medium flex-1 ${mode === 'text' ? 'bg-teal-500 text-white' : 'bg-gray-100 text-gray-700'}`}
@@ -52,6 +65,12 @@ function InputSection({ inputValue, onInputChange }) {
           </button>
         </div>
       )}
+      <button
+        onClick={onSubmit}
+        className="bg-teal-600 text-white rounded-md px-4 py-2 hover:bg-teal-700"
+      >
+        Submit
+      </button>
     </div>
   )
 }

--- a/my-app/src/OutputSection.jsx
+++ b/my-app/src/OutputSection.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+function OutputSection({ output }) {
+  if (!output) return null
+
+  return (
+    <div className="bg-teal-50 border border-teal-200 p-4 rounded-md shadow">
+      <h2 className="font-semibold mb-2 text-teal-800">Filtered Message</h2>
+      <p className="whitespace-pre-wrap text-gray-800">{output}</p>
+    </div>
+  )
+}
+
+export default OutputSection

--- a/my-app/src/PolitenessSlider.jsx
+++ b/my-app/src/PolitenessSlider.jsx
@@ -1,7 +1,4 @@
-import { useState } from 'react'
-
-function PolitenessSlider() {
-  const [level, setLevel] = useState(3)
+function PolitenessSlider({ level, onLevelChange }) {
 
   const getLabel = (value) => {
     switch (Number(value)) {
@@ -32,7 +29,7 @@ function PolitenessSlider() {
         max="5"
         step="1"
         value={level}
-        onChange={(e) => setLevel(Number(e.target.value))}
+        onChange={(e) => onLevelChange(Number(e.target.value))}
         className="w-full accent-teal-500"
       />
       <div className="text-sm text-gray-600 text-center">{getLabel(level)}</div>

--- a/my-app/src/RecipientSelector.jsx
+++ b/my-app/src/RecipientSelector.jsx
@@ -1,11 +1,11 @@
-import { useState } from 'react'
-
-function RecipientSelector() {
-  const [recipient, setRecipient] = useState('')
-  const [customRecipient, setCustomRecipient] = useState('')
-
+function RecipientSelector({
+  recipient,
+  customRecipient,
+  onRecipientChange,
+  onCustomRecipientChange,
+}) {
   const handleChange = (e) => {
-    setRecipient(e.target.value)
+    onRecipientChange(e.target.value)
   }
 
   return (
@@ -31,7 +31,7 @@ function RecipientSelector() {
           className="border border-gray-300 rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-teal-500"
           placeholder="Enter custom recipient"
           value={customRecipient}
-          onChange={(e) => setCustomRecipient(e.target.value)}
+          onChange={(e) => onCustomRecipientChange(e.target.value)}
         />
       )}
     </div>

--- a/my-app/src/RetrySection.jsx
+++ b/my-app/src/RetrySection.jsx
@@ -1,12 +1,6 @@
-import { useState } from 'react'
-
-function RetrySection({ previousInput }) {
-  const [feedback, setFeedback] = useState('')
-
+function RetrySection({ feedback, onFeedbackChange, onRetry }) {
   const handleRetry = () => {
-    console.log('Retrying with input:', previousInput, 'Feedback:', feedback)
-    // API call will be integrated here
-    setFeedback('')
+    onRetry()
   }
 
   return (
@@ -19,7 +13,7 @@ function RetrySection({ previousInput }) {
         className="w-full p-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-600 resize-none"
         placeholder="e.g., Make it shorter or Too formal"
         value={feedback}
-        onChange={(e) => setFeedback(e.target.value)}
+        onChange={(e) => onFeedbackChange(e.target.value)}
       />
       <button
         onClick={handleRetry}


### PR DESCRIPTION
## Summary
- add OutputSection to show filtered text
- pass recipient and level data back to App
- implement fetch logic to call OpenAI ChatGPT
- wire up RetrySection feedback
- ignore local `.env` file

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888ded4e760832b82b08722bd28f30c