### PR TITLE
Add OpenAI helper and polish output component

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ npm run dev
 ```
 
 Open `http://localhost:5173` in your browser to view the application.
+
+## Environment Variables
+
+Create a `.env` file inside `my-app` with your OpenAI key:
+
+```
+VITE_OPENAI_API_KEY=your-api-key
+```

--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -4,6 +4,7 @@ import InputSection from './InputSection.jsx'
 import PolitenessSlider from './PolitenessSlider.jsx'
 import RetrySection from './RetrySection.jsx'
 import OutputSection from './OutputSection.jsx'
+import callOpenAI from './utils/callOpenAI.js'
 
 function App() {
   const [inputText, setInputText] = useState('')
@@ -19,34 +20,15 @@ function App() {
   }
 
   const handleSubmit = async () => {
-    const promptParts = [
-      'Please rewrite this message to be more polite.',
-      `Audience: ${getAudience()}.`,
-      `Politeness level: ${politeness}.`,
-    ]
-    if (feedback) {
-      promptParts.push(`Feedback: ${feedback}.`)
-    }
-    promptParts.push(`Original message: ${inputText}`)
-
-    const prompt = promptParts.join(' ')
-
     setLoading(true)
     try {
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
-        },
-        body: JSON.stringify({
-          model: 'gpt-3.5-turbo',
-          messages: [{ role: 'user', content: prompt }],
-        }),
-      })
-
-      const data = await res.json()
-      setOutput(data.choices?.[0]?.message?.content?.trim() || '')
+      const result = await callOpenAI(
+        inputText,
+        getAudience(),
+        politeness,
+        feedback,
+      )
+      setOutput(result)
     } catch (err) {
       console.error(err)
       setOutput('Failed to fetch response.')

--- a/my-app/src/OutputSection.jsx
+++ b/my-app/src/OutputSection.jsx
@@ -4,9 +4,9 @@ function OutputSection({ output }) {
   if (!output) return null
 
   return (
-    <div className="bg-teal-50 border border-teal-200 p-4 rounded-md shadow">
-      <h2 className="font-semibold mb-2 text-teal-800">Filtered Message</h2>
-      <p className="whitespace-pre-wrap text-gray-800">{output}</p>
+    <div className="bg-white rounded p-4 shadow">
+      <h2 className="font-semibold mb-2">Filtered Output</h2>
+      <p className="whitespace-pre-wrap text-gray-700">{output}</p>
     </div>
   )
 }

--- a/my-app/src/utils/callOpenAI.js
+++ b/my-app/src/utils/callOpenAI.js
@@ -1,0 +1,32 @@
+export default async function callOpenAI(inputText, recipient, politenessLevel, feedback = '') {
+  const promptParts = [
+    'Please rewrite this message to be more polite and respectful.',
+    `Audience: ${recipient}.`,
+    `Politeness level: ${politenessLevel}.`,
+  ]
+  if (feedback) {
+    promptParts.push(`Feedback: ${feedback}.`)
+  }
+  promptParts.push(`Message: ${inputText}`)
+
+  const prompt = promptParts.join(' ')
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  })
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch response')
+  }
+
+  const data = await res.json()
+  return data.choices?.[0]?.message?.content?.trim() || ''
+}


### PR DESCRIPTION
## Summary
- move API call logic to `callOpenAI` helper
- update output section styling
- document how to provide the OpenAI key

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888e18a828c832ba4ba5e2b0b59d00c