### PR TITLE
Handle missing OpenAI API key gracefully

### DIFF
--- a/my-app/src/App.jsx
+++ b/my-app/src/App.jsx
@@ -14,6 +14,7 @@ function App() {
   const [feedback, setFeedback] = useState('')
   const [output, setOutput] = useState('')
   const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
 
   const getAudience = () => {
     return recipient === 'Custom' ? customRecipient || 'Custom' : recipient || 'General'
@@ -21,6 +22,7 @@ function App() {
 
   const handleSubmit = async () => {
     setLoading(true)
+    setError('')
     try {
       const result = await callOpenAI(
         inputText,
@@ -31,7 +33,8 @@ function App() {
       setOutput(result)
     } catch (err) {
       console.error(err)
-      setOutput('Failed to fetch response.')
+      setError(err.message || 'Failed to fetch response.')
+      setOutput('')
     } finally {
       setLoading(false)
     }
@@ -57,7 +60,7 @@ function App() {
       {loading ? (
         <div className="text-center text-gray-600">Filtering...</div>
       ) : (
-        <OutputSection output={output} />
+        <OutputSection output={output} error={error} />
       )}
     </div>
   )

--- a/my-app/src/OutputSection.jsx
+++ b/my-app/src/OutputSection.jsx
@@ -1,12 +1,18 @@
 import React from 'react'
 
-function OutputSection({ output }) {
-  if (!output) return null
+function OutputSection({ output, error }) {
+  if (!output && !error) return null
 
   return (
     <div className="bg-white rounded p-4 shadow">
-      <h2 className="font-semibold mb-2">Filtered Output</h2>
-      <p className="whitespace-pre-wrap text-gray-700">{output}</p>
+      {error ? (
+        <div className="bg-red-100 text-red-700 p-3 rounded">{error}</div>
+      ) : (
+        <>
+          <h2 className="font-semibold mb-2">Filtered Output</h2>
+          <p className="whitespace-pre-wrap text-gray-700">{output}</p>
+        </>
+      )}
     </div>
   )
 }

--- a/my-app/src/utils/callOpenAI.js
+++ b/my-app/src/utils/callOpenAI.js
@@ -1,4 +1,10 @@
 export default async function callOpenAI(inputText, recipient, politenessLevel, feedback = '') {
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY
+  if (!apiKey) {
+    console.warn('OpenAI API key is missing.')
+    throw new Error('API key is missing. Please check your .env setup.')
+  }
+
   const promptParts = [
     'Please rewrite this message to be more polite and respectful.',
     `Audience: ${recipient}.`,
@@ -15,7 +21,7 @@ export default async function callOpenAI(inputText, recipient, politenessLevel, 
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${import.meta.env.VITE_OPENAI_API_KEY}`,
+      Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
       model: 'gpt-3.5-turbo',


### PR DESCRIPTION
## Summary
- warn and throw an explicit error if `VITE_OPENAI_API_KEY` is missing
- surface OpenAI call errors in the app UI
- show red alert in the output section when an error occurs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6888e449a940832b9207cb96f898a23e